### PR TITLE
EVG-13009: allow credentials profile to be specified without credentials filepath

### DIFF
--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -166,18 +166,7 @@ func newS3BucketBase(client *http.Client, options S3Options) (*s3Bucket, error) 
 		MaxRetries: aws.Int(options.MaxRetries),
 	}
 
-	if options.SharedCredentialsProfile != "" {
-		prev := os.Getenv("AWS_PROFILE")
-		if err := os.Setenv("AWS_PROFILE", options.SharedCredentialsProfile); err != nil {
-			return nil, errors.Wrap(err, "problem setting AWS_PROFILE env var")
-		}
-		defer func() {
-			if err := os.Setenv("AWS_PROFILE", prev); err != nil {
-				grip.Error(errors.Wrap(err, "problem setting back AWS_PROFILE env var"))
-			}
-		}()
-	}
-	if options.SharedCredentialsFilepath != "" {
+	if options.SharedCredentialsFilepath != "" || options.SharedCredentialsProfile != "" {
 		sharedCredentials := credentials.NewSharedCredentials(options.SharedCredentialsFilepath, options.SharedCredentialsProfile)
 		_, err := sharedCredentials.Get()
 		if err != nil {

--- a/s3_bucket_util_test.go
+++ b/s3_bucket_util_test.go
@@ -101,6 +101,15 @@ func getS3SmallBucketTests(ctx context.Context, tempdir string, s3Credentials *c
 			test: func(t *testing.T, b Bucket) {
 				require.NoError(t, b.Check(ctx))
 
+				homeDir, err := homedir.Dir()
+				require.NoError(t, err)
+				fileName := filepath.Join(homeDir, ".aws", "credentials")
+
+				if _, err := os.Stat(fileName); os.IsNotExist(err) {
+					t.Skip("static credentials file not present")
+				}
+				require.NoError(t, b.Check(ctx))
+
 				sharedCredsOptions := S3Options{
 					SharedCredentialsProfile: "default",
 					Region:                   s3Region,
@@ -108,15 +117,7 @@ func getS3SmallBucketTests(ctx context.Context, tempdir string, s3Credentials *c
 				}
 				sharedCredsBucket, err := NewS3Bucket(sharedCredsOptions)
 				require.NoError(t, err)
-				homeDir, err := homedir.Dir()
-				require.NoError(t, err)
-				fileName := filepath.Join(homeDir, ".aws", "credentials")
-				_, err = os.Stat(fileName)
-				if err == nil {
-					assert.NoError(t, sharedCredsBucket.Check(ctx))
-				} else {
-					assert.True(t, os.IsNotExist(err))
-				}
+				assert.NoError(t, sharedCredsBucket.Check(ctx))
 			},
 		},
 		{
@@ -379,6 +380,14 @@ func getS3LargeBucketTests(ctx context.Context, tempdir string, s3Credentials *c
 			test: func(t *testing.T, b Bucket) {
 				require.NoError(t, b.Check(ctx))
 
+				homeDir, err := homedir.Dir()
+				require.NoError(t, err)
+				fileName := filepath.Join(homeDir, ".aws", "credentials")
+
+				if _, err := os.Stat(fileName); os.IsNotExist(err) {
+					t.Skip("static credentials file not present")
+				}
+
 				sharedCredsOptions := S3Options{
 					SharedCredentialsProfile: "default",
 					Region:                   s3Region,
@@ -386,15 +395,7 @@ func getS3LargeBucketTests(ctx context.Context, tempdir string, s3Credentials *c
 				}
 				sharedCredsBucket, err := NewS3MultiPartBucket(sharedCredsOptions)
 				require.NoError(t, err)
-				homeDir, err := homedir.Dir()
-				require.NoError(t, err)
-				fileName := filepath.Join(homeDir, ".aws", "credentials")
-				_, err = os.Stat(fileName)
-				if err == nil {
-					assert.NoError(t, sharedCredsBucket.Check(ctx))
-				} else {
-					assert.True(t, os.IsNotExist(err))
-				}
+				assert.NoError(t, sharedCredsBucket.Check(ctx))
 			},
 		},
 		{

--- a/s3_bucket_util_test.go
+++ b/s3_bucket_util_test.go
@@ -105,7 +105,7 @@ func getS3SmallBucketTests(ctx context.Context, tempdir string, s3Credentials *c
 				require.NoError(t, err)
 				fileName := filepath.Join(homeDir, ".aws", "credentials")
 
-				if _, err := os.Stat(fileName); os.IsNotExist(err) {
+				if _, err = os.Stat(fileName); os.IsNotExist(err) {
 					t.Skip("static credentials file not present")
 				}
 				require.NoError(t, b.Check(ctx))
@@ -384,7 +384,7 @@ func getS3LargeBucketTests(ctx context.Context, tempdir string, s3Credentials *c
 				require.NoError(t, err)
 				fileName := filepath.Join(homeDir, ".aws", "credentials")
 
-				if _, err := os.Stat(fileName); os.IsNotExist(err) {
+				if _, err = os.Stat(fileName); os.IsNotExist(err) {
 					t.Skip("static credentials file not present")
 				}
 

--- a/s3_bucket_util_test.go
+++ b/s3_bucket_util_test.go
@@ -130,9 +130,8 @@ func getS3SmallBucketTests(ctx context.Context, tempdir string, s3Credentials *c
 					Name:                     s3BucketName,
 				}
 				sharedCredsBucket, err := NewS3Bucket(sharedCredsOptions)
-				assert.NoError(t, err)
-				_, err = sharedCredsBucket.List(ctx, "")
 				assert.Error(t, err)
+				assert.Zero(t, sharedCredsBucket)
 			},
 		},
 		{
@@ -409,9 +408,8 @@ func getS3LargeBucketTests(ctx context.Context, tempdir string, s3Credentials *c
 					Name:                     s3BucketName,
 				}
 				sharedCredsBucket, err := NewS3MultiPartBucket(sharedCredsOptions)
-				assert.NoError(t, err)
-				_, err = sharedCredsBucket.List(ctx, "")
 				assert.Error(t, err)
+				assert.Zero(t, sharedCredsBucket)
 			},
 		},
 		{


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13009

Right now the `SharedCredentialsProfile` doesn't actually work because it just sets an env var and unsets it once the bucket is initialized, which doesn't actually set any credentials unless you specify `SharedCredentialsFilepath`. Therefore, if you use `SharedCredentialsProfile` without `SharedCredentialsFilepath`, it won't be able to use the credentials in `~/.aws/credentials` as you might expect. Now, if you specify just `SharedCredentialsProfile` without `SharedCredentialsFilepath`, you'll use that profile with the `~/.aws/credentials` file by default.