### PR TITLE
EVG-14486: use archlinux-new distros in CI tests

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -154,7 +154,7 @@ buildvariants:
       RACE_DETECTOR: true
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
     run_on:
-      - archlinux-test
+      - archlinux-new-small
     tasks:
       - name: ".test"
 
@@ -165,7 +165,7 @@ buildvariants:
       GOROOT: /opt/golang/go1.13
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
     run_on:
-      - archlinux-test
+      - archlinux-new-small
     tasks:
       - name: ".report"
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14486