### PR TITLE
EVG-14482, EVG-14502: upgrade go version and upgrade linter

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -54,7 +54,7 @@ functions:
       working_dir: gopath/src/github.com/evergreen-ci/pail
       binary: make
       args: ["${target}"]
-      add_expansions_to_env: true
+      include_expansions_in_env: ["DISABLE_COVERAGE", "GO_BIN_PATH", "GOROOT", "RACE_DETECTOR"]
       env:
         GOPATH: ${workdir}/gopath
         AWS_KEY: ${aws_key}
@@ -94,7 +94,7 @@ post:
     params:
       aws_key: ${aws_s3_key}
       aws_secret: ${aws_s3_secret}
-      local_files_include_filter: ["gopath/src/github.com/evergreen-ci/pail/build/output.*.cover.html"]
+      local_files_include_filter: ["gopath/src/github.com/evergreen-ci/pail/build/output.*.coverage.html"]
       remote_file: pail/${task_id}/
       bucket: mciuploads
       content_type: text/html
@@ -149,8 +149,8 @@ buildvariants:
     display_name: Race Detector (Arch Linux)
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
-      GOROOT: /opt/golang/go1.13
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
       RACE_DETECTOR: true
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
     run_on:
@@ -161,23 +161,23 @@ buildvariants:
   - name: coverage
     display_name: Coverage (Arch Linux)
     expansions:
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
-      GOROOT: /opt/golang/go1.13
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
     run_on:
       - archlinux-new-small
     tasks:
       - name: ".report"
 
-  - name: ubuntu1604
-    display_name: Ubuntu 16.04
+  - name: ubuntu
+    display_name: Ubuntu 18.04
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.9/bin/go
-      GOROOT: /opt/golang/go1.9
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
     run_on:
-      - ubuntu1604-test
+      - ubuntu1804-small
     tasks:
       - name: ".test"
 
@@ -185,8 +185,8 @@ buildvariants:
     display_name: macOS 10.14
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
-      GOROOT: /opt/golang/go1.13
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.1.tgz
     run_on:
       - macos-1014
@@ -202,8 +202,8 @@ buildvariants:
       - windows-64-vs2017-large
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /cygdrive/c/golang/go1.13/bin/go
-      GOROOT: C:/golang/go1.13
+      GO_BIN_PATH: /cygdrive/c/golang/go1.16/bin/go
+      GOROOT: C:/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.1.zip
     tasks:
       - name: ".test"

--- a/makefile
+++ b/makefile
@@ -21,6 +21,7 @@ endif
 export GOPATH := $(gopath)
 export GOCACHE := $(gocache)
 export GOROOT := $(goroot)
+export GO111MODULE := off
 # end environment setup
 
 
@@ -31,7 +32,7 @@ $(shell mkdir -p $(buildDir))
 # start lint setup targets
 lintDeps := $(buildDir)/run-linter $(buildDir)/golangci-lint
 $(buildDir)/golangci-lint:
-	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.30.0 >/dev/null 2>&1
+	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	@$(gobin) build -o $@ $<
 # end lint setup targets


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-14482
https://jira.mongodb.org/browse/EVG-14502

* Upgrade go to 1.16.
* Upgrade golangci-lint to 1.40.
* Upgrade Ubuntu to 18.04.