### PR TITLE
EVG-14708: set up ECS client interface

### DIFF
--- a/ecs/client.go
+++ b/ecs/client.go
@@ -14,7 +14,7 @@ type Client interface {
 	// RegisterTaskDefinition registers the definition for a new task with ECS.
 	RegisterTaskDefinition(context.Context, *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error)
 	// DeregisterTaskDefinition deregisters an existing ECS task definition.
-	DeregisterTaskDefinition(ctx context.Context, id string) (*ecs.DeregisterContainerInstanceOutput, error)
+	DeregisterTaskDefinition(ctx context.Context, in *ecs.DeregisterTaskDefinitionInput) (*ecs.DeregisterContainerInstanceOutput, error)
 	// RunTask runs a registered task.
 	RunTask(ctx context.Context, in *ecs.RunTaskInput) (*ecs.RunTaskOutput, error)
 	// Close closes the client and cleans up its resources. Implementations

--- a/ecs/client.go
+++ b/ecs/client.go
@@ -14,12 +14,15 @@ type Client interface {
 	// RegisterTaskDefinition registers the definition for a new task with ECS.
 	RegisterTaskDefinition(context.Context, *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error)
 	// DeregisterTaskDefinition deregisters an existing ECS task definition.
-	DeregisterTaskDefinition(context.Context, *ecs.DeregisterTaskDefinitionInput) (*ecs.DeregisterContainerInstanceOutput, error)
+	DeregisterTaskDefinition(ctx context.Context, id string) (*ecs.DeregisterContainerInstanceOutput, error)
 	// RunTask runs a registered task.
-	RunTask(context.Context, *ecs.RunTaskInput) (*ecs.RunTaskOutput, error)
+	RunTask(ctx context.Context, in *ecs.RunTaskInput) (*ecs.RunTaskOutput, error)
+	// Close closes the client and cleans up its resources. Implementations
+	// should ensure that this is idempotent.
+	Close(ctx context.Context) error
 }
 
-// ECSClient provides an implementation that wraps the ECS API.
+// ECSClient provides a Client implementation that wraps the ECS API.
 type ECSClient struct {
 }
 
@@ -33,4 +36,8 @@ func (c *ECSClient) DeregisterTaskDefinition(context.Context, *ecs.RegisterTaskD
 
 func (c *ECSClient) RunTask(context.Context, *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterContainerInstanceOutput, error) {
 	return nil, errors.New("TODO: implement")
+}
+
+func (c *ECSClient) Close(ctx context.Context) error {
+	return errors.New("TODO: implement")
 }

--- a/ecs/client.go
+++ b/ecs/client.go
@@ -1,0 +1,36 @@
+package ecs
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+)
+
+// Client provides a common interface to interact with an ECS client and its
+// mock implementation for testing. Implementations must handle retrying and
+// backoff.
+type Client interface {
+	// RegisterTaskDefinition registers the definition for a new task with ECS.
+	RegisterTaskDefinition(context.Context, *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error)
+	// DeregisterTaskDefinition deregisters an existing ECS task definition.
+	DeregisterTaskDefinition(context.Context, *ecs.DeregisterTaskDefinitionInput) (*ecs.DeregisterContainerInstanceOutput, error)
+	// RunTask runs a registered task.
+	RunTask(context.Context, *ecs.RunTaskInput) (*ecs.RunTaskOutput, error)
+}
+
+// ECSClient provides an implementation that wraps the ECS API.
+type ECSClient struct {
+}
+
+func (c *ECSClient) RegisterTaskDefinition(context.Context, *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterContainerInstanceOutput, error) {
+	return nil, errors.New("TODO: implement")
+}
+
+func (c *ECSClient) DeregisterTaskDefinition(context.Context, *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterContainerInstanceOutput, error) {
+	return nil, errors.New("TODO: implement")
+}
+
+func (c *ECSClient) RunTask(context.Context, *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterContainerInstanceOutput, error) {
+	return nil, errors.New("TODO: implement")
+}

--- a/ecs/client.go
+++ b/ecs/client.go
@@ -23,8 +23,7 @@ type Client interface {
 }
 
 // ECSClient provides a Client implementation that wraps the ECS API.
-type ECSClient struct {
-}
+type ECSClient struct{}
 
 func (c *ECSClient) RegisterTaskDefinition(context.Context, *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterContainerInstanceOutput, error) {
 	return nil, errors.New("TODO: implement")

--- a/ecs/doc.go
+++ b/ecs/doc.go
@@ -1,0 +1,9 @@
+/*
+Package ecs provides interfaces to interact with AWS ECS, a container
+orchestration service. Containers are not managed individually - they're managed
+as logical groupings of containers called tasks.
+
+The Client interface provides a convenience wrapper around the ECS API. A mock
+implementation for testing purposes is also available in the testutil package.
+*/
+package ecs

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -7,9 +7,8 @@ ignore:
 #######################################
 variables:
   - &run-build
-    # runs a build operations. The task name in evergreen should
+    # runs a build operation. The task name in evergreen should
     # correspond to a make target for the build operation.
-    name: test
     commands:
       - command: git.get_project
         type: system
@@ -33,7 +32,6 @@ variables:
   - &run-build-with-mongodb
     # runs a make target above, but only on systems that have a
     # running mongod started for testing.
-    name: test
     commands:
       - command: git.get_project
         type: system
@@ -117,6 +115,7 @@ tasks:
   # a template that does not include test result parsing.
   - name: lint
     tags: ["report"]
+    must_have_test_results: true
     commands:
       - command: git.get_project
         type: system
@@ -127,6 +126,7 @@ tasks:
 
   - name: coverage
     tags: [ "report" ]
+    must_have_test_results: true
     commands:
       - command: git.get_project
         type: system
@@ -139,7 +139,8 @@ tasks:
 
   - <<: *run-build-with-mongodb
     tags: ["test"]
-    name: test
+    name: test-pail
+    must_have_test_results: true
 
 #######################################
 #           Buildvariants             #

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 buildDir := build
 name := pail
-packages := $(name)
+packages := $(name) ecs
 projectPath := github.com/evergreen-ci/pail
 
 
@@ -105,6 +105,19 @@ lint:$(foreach target,$(packages),$(buildDir)/output.$(target).lint)
 phony += lint $(buildDir) test coverage coverage-html
 .PRECIOUS: $(coverageOutput) $(coverageHtmlOutput) $(lintOutput) $(testOutput)
 # end front-ends
+
+
+# convenience targets for running tests and coverage tasks on a
+# specific package.
+test-%: $(buildDir)/output.%.test
+	
+coverage-%: $(buildDir)/output.%.coverage
+	
+html-coverage-%: $(buildDir)/output.%.coverage.html
+	
+lint-%: $(buildDir)/output.%.lint
+	
+# end convienence targets
 
 
 compile $(buildDir):

--- a/testutil/ecs.go
+++ b/testutil/ecs.go
@@ -1,0 +1,23 @@
+package testutil
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/pkg/errors"
+)
+
+// MockECSClient provides a mock implementation of an ecs.Client, which can be
+// used for testing purposes and introspection.
+type MockECSClient struct {
+}
+
+func (c *MockECSClient) RegisterTaskDefinition(context.Context, *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterContainerInstanceOutput, error) {
+	return nil, errors.New("TODO: implement")
+}
+func (c *MockECSClient) DeregisterTaskDefinition(context.Context, *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterContainerInstanceOutput, error) {
+	return nil, errors.New("TODO: implement")
+}
+func (c *MockECSClient) RunTask(context.Context, *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterContainerInstanceOutput, error) {
+	return nil, errors.New("TODO: implement")
+}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14708

This creates a new package with the ECS client interface and updates the tests to handle multiple packages. The client only deals with interacting with the ECS API. I thought it might be nice to have a manager to do common ECS operations, but it seems like the management would depend on the data model of the application. Since pail doesn't deal with application data models, I think the management layer should be written in Evergreen/Cedar, wherever the logic applies.