### PR TITLE
EVG-15478: disable cgo

### DIFF
--- a/makefile
+++ b/makefile
@@ -19,6 +19,12 @@ export GOROOT := $(shell cygpath -m $(GOROOT))
 endif
 
 export GO111MODULE := off
+ifneq (,$(RACE_DETECTOR))
+# cgo is required for using the race detector.
+export CGO_ENABLED=1
+else
+export CGO_ENABLED=0
+endif
 # end environment setup
 
 # Ensure the build directory exists, since most targets require it.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15478

Evergreen is compiled without cgo so it's preferable to test/compile without cgo in all repos to avoid discrepancies in behavior.