### PR TITLE
EVG-16477 Move s3.go to pail

### DIFF
--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -10,11 +10,13 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/evergreen-ci/utility"
@@ -1322,4 +1324,65 @@ func (s *s3ArchiveBucket) Pull(ctx context.Context, opts SyncOptions) error {
 	}
 
 	return nil
+}
+
+// PresignExpireTime sets the amount of time the link is live before expiring.
+const PresignExpireTime = 24 * time.Hour
+
+// RequestParams holds all the parameters needed to sign a url or fetch headObject.
+type RequestParams struct {
+	Bucket    string `json:"bucket"`
+	FileKey   string `json:"fileKey"`
+	AwsKey    string `json:"awsKey"`
+	AwsSecret string `json:"awsSecret"`
+	Region    string `json:"region"`
+}
+
+// PreSign returns a presigned url that expires in 24 hours.
+func PreSign(r RequestParams) (string, error) {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(endpoints.UsEast1RegionID),
+		Credentials: credentials.NewStaticCredentialsFromCreds(credentials.Value{
+			AccessKeyID:     r.AwsKey,
+			SecretAccessKey: r.AwsSecret,
+		}),
+	})
+	if err != nil {
+		return "", err
+	}
+	svc := s3.New(sess)
+
+	req, _ := svc.GetObjectRequest(&s3.GetObjectInput{
+		Bucket: aws.String(r.Bucket),
+		Key:    aws.String(r.FileKey),
+	})
+
+	urlStr, err := req.Presign(PresignExpireTime)
+	return urlStr, err
+}
+
+// GetHeadObject fetches the metadata of an s3 object.
+func GetHeadObject(r RequestParams) (*s3.HeadObjectOutput, error) {
+	session, err := session.NewSession(&aws.Config{
+		Region: aws.String(r.Region),
+		Credentials: credentials.NewStaticCredentialsFromCreds(credentials.Value{
+			AccessKeyID:     r.AwsKey,
+			SecretAccessKey: r.AwsSecret,
+		}),
+	})
+	if err != nil {
+		return nil, err
+	}
+	svc := s3.New(session)
+
+	headObject, err := svc.HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(r.Bucket),
+		Key:    aws.String(r.FileKey),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return headObject, nil
 }

--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -1329,8 +1329,8 @@ func (s *s3ArchiveBucket) Pull(ctx context.Context, opts SyncOptions) error {
 // PresignExpireTime sets the amount of time the link is live before expiring.
 const PresignExpireTime = 24 * time.Hour
 
-// RequestParams holds all the parameters needed to sign a url or fetch headObject.
-type RequestParams struct {
+// PreSignRequestParams holds all the parameters needed to sign a URL or fetch S3 object metadata.
+type PreSignRequestParams struct {
 	Bucket    string `json:"bucket"`
 	FileKey   string `json:"fileKey"`
 	AwsKey    string `json:"awsKey"`
@@ -1338,8 +1338,8 @@ type RequestParams struct {
 	Region    string `json:"region"`
 }
 
-// PreSign returns a presigned url that expires in 24 hours.
-func PreSign(r RequestParams) (string, error) {
+// PreSign returns a presigned URL that expires in 24 hours.
+func PreSign(r PreSignRequestParams) (string, error) {
 	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(endpoints.UsEast1RegionID),
 		Credentials: credentials.NewStaticCredentialsFromCreds(credentials.Value{
@@ -1348,7 +1348,7 @@ func PreSign(r RequestParams) (string, error) {
 		}),
 	})
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "connecting to AWS")
 	}
 	svc := s3.New(sess)
 
@@ -1361,8 +1361,8 @@ func PreSign(r RequestParams) (string, error) {
 	return urlStr, err
 }
 
-// GetHeadObject fetches the metadata of an s3 object.
-func GetHeadObject(r RequestParams) (*s3.HeadObjectOutput, error) {
+// GetHeadObject fetches the metadata of an S3 object.
+func GetHeadObject(r PreSignRequestParams) (*s3.HeadObjectOutput, error) {
 	session, err := session.NewSession(&aws.Config{
 		Region: aws.String(r.Region),
 		Credentials: credentials.NewStaticCredentialsFromCreds(credentials.Value{


### PR DESCRIPTION
[EVG-16477](https://jira.mongodb.org/browse/EVG-16477)
The functions in [s3.go|https://github.com/evergreen-ci/evergreen/blob/main/thirdparty/s3.go ] should live here. 
This repo is a more appropriate place for it as it'll help us reduce the amount of miscellaneous third-party code in evergreen. 

Once this is merge, I'll create the corresponding evergreen PR. 