### PR TITLE
EVG-17526: s3bucket: remove quotes from etag

### DIFF
--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -1187,7 +1187,7 @@ func (iter *s3BucketIterator) Next(ctx context.Context) bool {
 	iter.item = &bucketItemImpl{
 		bucket: iter.s.name,
 		key:    iter.s.denormalizeKey(*iter.contents[iter.idx].Key),
-		hash:   *iter.contents[iter.idx].ETag,
+		hash:   strings.Trim(*iter.contents[iter.idx].ETag, `"`),
 		b:      iter.b,
 	}
 	return true


### PR DESCRIPTION
S3 returns its ETag, which we use as an S3 bucket item's hash, with
double quotes at each end of the string. This has silently caused
our local file caching with UseSingleFileChecksums to fail because
we ended up comparing hashes like "abc123" == abc123 and deciding
they were different. This commit fixes this so that all ETags will
have their quotes stripped. There is also a test which explicitly
checks that a file we know to exist locally does not get modified
when we call bucket.Pull().

Also of note: An ETag is not guaranteed to be an MD5 hash, but that
is what is currently being used for caching files. We should look
into alternatives to this in the future which could include
calculating our own ETag for local files or looking at other
metadata we can attach on S3 uploads.