### PR TITLE
EVG-17661 default MaxRetries

### DIFF
--- a/benchmarks/harness.go
+++ b/benchmarks/harness.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/evergreen-ci/pail"
 	"github.com/evergreen-ci/pail/testutil"
 	"github.com/evergreen-ci/poplar"
@@ -336,7 +337,7 @@ func s3Opts() pail.S3Options {
 		Region:      "us-east-1",
 		Name:        "build-test-curator",
 		Prefix:      testutil.NewUUID(),
-		MaxRetries:  20,
+		MaxRetries:  aws.Int(20),
 	}
 }
 

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/evergreen-ci/pail/testutil"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -240,7 +241,7 @@ func TestBucket(t *testing.T) {
 					Region:      s3Region,
 					Name:        s3BucketName,
 					Prefix:      s3Prefix + testutil.NewUUID(),
-					MaxRetries:  20,
+					MaxRetries:  aws.Int(20),
 				}
 				b, err := NewS3Bucket(s3Options)
 				require.NoError(t, err)
@@ -256,7 +257,7 @@ func TestBucket(t *testing.T) {
 					Region:                 s3Region,
 					Name:                   s3BucketName,
 					Prefix:                 s3Prefix + testutil.NewUUID(),
-					MaxRetries:             20,
+					MaxRetries:             aws.Int(20),
 					UseSingleFileChecksums: true,
 				}
 				b, err := NewS3Bucket(s3Options)
@@ -286,7 +287,7 @@ func TestBucket(t *testing.T) {
 					Region:                 s3Region,
 					Name:                   s3BucketName,
 					Prefix:                 s3Prefix + testutil.NewUUID(),
-					MaxRetries:             20,
+					MaxRetries:             aws.Int(20),
 					UseSingleFileChecksums: true,
 				}
 				b, err := NewS3Bucket(s3Options)
@@ -305,7 +306,7 @@ func TestBucket(t *testing.T) {
 					Region:      s3Region,
 					Name:        s3BucketName,
 					Prefix:      s3Prefix + testutil.NewUUID(),
-					MaxRetries:  20,
+					MaxRetries:  aws.Int(20),
 				}
 				b, err := NewS3MultiPartBucket(s3Options)
 				require.NoError(t, err)
@@ -321,7 +322,7 @@ func TestBucket(t *testing.T) {
 					Region:                 s3Region,
 					Name:                   s3BucketName,
 					Prefix:                 s3Prefix + testutil.NewUUID(),
-					MaxRetries:             20,
+					MaxRetries:             aws.Int(20),
 					UseSingleFileChecksums: true,
 				}
 				b, err := NewS3MultiPartBucket(s3Options)
@@ -1132,7 +1133,7 @@ func TestS3ArchiveBucket(t *testing.T) {
 					Region:      s3Region,
 					Name:        s3BucketName,
 					Prefix:      s3Prefix + testutil.NewUUID(),
-					MaxRetries:  20,
+					MaxRetries:  aws.Int(20),
 				}
 				bucket, err := NewS3ArchiveBucket(s3Options)
 				require.NoError(t, err)

--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -105,7 +105,8 @@ type S3Options struct {
 	// Verbose sets the logging mode to "debug".
 	Verbose bool
 	// MaxRetries sets the number of retry attempts for S3 operations.
-	MaxRetries int
+	// By default it defers to the AWS SDK's default.
+	MaxRetries *int
 	// Credentials allows the passing in of explicit AWS credentials. These
 	// will override the default credentials chain. (Optional)
 	Credentials *credentials.Credentials
@@ -176,7 +177,7 @@ func newS3BucketBase(client *http.Client, options S3Options) (*s3Bucket, error) 
 	config := &aws.Config{
 		Region:     aws.String(options.Region),
 		HTTPClient: client,
-		MaxRetries: aws.Int(options.MaxRetries),
+		MaxRetries: options.MaxRetries,
 	}
 
 	if options.SharedCredentialsFilepath != "" || options.SharedCredentialsProfile != "" {

--- a/s3_bucket_util_test.go
+++ b/s3_bucket_util_test.go
@@ -250,7 +250,7 @@ func getS3SmallBucketTests(ctx context.Context, tempdir string, s3Credentials *c
 					Region:      s3Region,
 					Name:        s3BucketName,
 					Prefix:      rawBucket.prefix,
-					MaxRetries:  20,
+					MaxRetries:  aws.Int(20),
 					Compress:    true,
 				}
 				cb, err := NewS3Bucket(s3Options)
@@ -553,7 +553,7 @@ func getS3LargeBucketTests(ctx context.Context, tempdir string, s3Credentials *c
 					Region:      s3Region,
 					Name:        s3BucketName,
 					Prefix:      rawBucket.prefix,
-					MaxRetries:  20,
+					MaxRetries:  aws.Int(20),
 					Compress:    true,
 				}
 				cb, err := NewS3MultiPartBucket(s3Options)


### PR DESCRIPTION
[EVG-17661](https://jira.mongodb.org/browse/EVG-17661)

If the value for MaxRetries is not provided this PR will make us fall back to [the SDK's default](https://github.com/aws/aws-sdk-go/blob/2f6c8c48d30e47f5ec3ac2a59bd521fafb99d69d/aws/client/default_retryer.go#L39-L40).