### PR TITLE
EVG-20170: add Join function to Bucket interface

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -1321,7 +1321,7 @@ func writeDataToArchive(ctx context.Context, bucket *s3ArchiveBucket, prefix str
 	wctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	writer, err := bucket.Writer(wctx, consistentJoin(prefix, syncArchiveName))
+	writer, err := bucket.Writer(wctx, bucket.Join(prefix, syncArchiveName))
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -1349,7 +1349,7 @@ func readDataFromArchive(ctx context.Context, bucket *s3ArchiveBucket, prefix st
 
 	data := map[string]string{}
 
-	reader, err := bucket.Reader(rctx, consistentJoin(prefix, syncArchiveName))
+	reader, err := bucket.Reader(rctx, bucket.Join(prefix, syncArchiveName))
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/interface.go
+++ b/interface.go
@@ -19,7 +19,7 @@ import (
 //   - https://github.com/evergreen-ci/evergreen/blob/master/thirdparty/s3.go
 //   - https://github.com/mongodb/curator/tree/master/sthree
 //
-// The preferred aws sdk is here: https://docs.aws.amazon.com/sdk-for-go/api/
+// The preferred AWS SDK is here: https://docs.aws.amazon.com/sdk-for-go/api/
 //
 // In no particular order:
 //   - implementation constructors should make it possible to use
@@ -40,13 +40,18 @@ type Bucket interface {
 	// Exists returns whether the given key exists in the bucket or not.
 	Exists(context.Context, string) (bool, error)
 
+	// Join concatenates elements with the appropriate path separator of
+	// the bucket, ignoring empty elements. This is analogous to
+	// `filepath.Join`.
+	Join(...string) string
+
 	// Produces a Writer and Reader interface to the file named by
 	// the string.
 	Writer(context.Context, string) (io.WriteCloser, error)
 	Reader(context.Context, string) (io.ReadCloser, error)
 
 	// Put and Get write simple byte streams (in the form of
-	// io.Readers) to/from specfied keys.
+	// io.Readers) to/from specified keys.
 	//
 	// TODO: consider if these, particularly Get are not
 	// substantively different from Writer/Reader methods, or
@@ -90,7 +95,7 @@ type Bucket interface {
 // the local file system tree with the remote store.
 type SyncBucket interface {
 	// Sync methods: these methods are the recursive, efficient
-	// copy methods of files from s3 to the local file
+	// copy methods of files from S3 to the local file
 	// system.
 	Push(context.Context, SyncOptions) error
 	Pull(context.Context, SyncOptions) error
@@ -119,7 +124,7 @@ type CopyOptions struct {
 // While iterators (typically) use channels internally, this is a
 // fairly standard paradigm for iterating through resources, and is
 // use heavily in the FTDC library (https://github.com/mongodb/ftdc)
-// and bson (https://godoc.org/github.com/mongodb/mongo-go-driver/bson)
+// and BSON (https://godoc.org/github.com/mongodb/mongo-go-driver/bson)
 // libraries.
 
 // BucketIterator provides a way to interact with the contents of a

--- a/local.go
+++ b/local.go
@@ -112,6 +112,8 @@ func (b *localFileSystem) Exists(_ context.Context, key string) (bool, error) {
 	return true, nil
 }
 
+func (b *localFileSystem) Join(elems ...string) string { return filepath.Join(elems...) }
+
 func (b *localFileSystem) Writer(_ context.Context, name string) (io.WriteCloser, error) {
 	grip.DebugWhen(b.verbose, message.Fields{
 		"type":          "local",

--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -153,7 +153,10 @@ func (s *s3Bucket) normalizeKey(key string) string {
 	if key == "" {
 		return s.prefix
 	}
-	return consistentJoin(s.prefix, key)
+	if s.prefix == "" {
+		return key
+	}
+	return s.Join(s.prefix, key)
 }
 
 func (s *s3Bucket) denormalizeKey(key string) string {
@@ -308,6 +311,17 @@ func (s *s3Bucket) Exists(ctx context.Context, key string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func (s *s3Bucket) Join(elems ...string) string {
+	var out []string
+	for _, elem := range elems {
+		if elem != "" {
+			out = append(out, elem)
+		}
+	}
+
+	return strings.Join(out, "/")
 }
 
 type smallWriteCloser struct {
@@ -877,7 +891,7 @@ func (s *s3Bucket) pushHelper(ctx context.Context, b Bucket, opts SyncOptions) e
 			continue
 		}
 
-		target := consistentJoin(opts.Remote, fn)
+		target := s.Join(opts.Remote, fn)
 		file := filepath.Join(opts.Local, fn)
 		shouldUpload, err := s.s3WithUploadChecksumHelper(ctx, target, file)
 		if err != nil {
@@ -967,7 +981,7 @@ func (s *s3BucketLarge) Pull(ctx context.Context, opts SyncOptions) error {
 func (s *s3Bucket) Copy(ctx context.Context, options CopyOptions) error {
 	if !options.IsDestination {
 		options.IsDestination = true
-		options.SourceKey = consistentJoin(s.name, s.normalizeKey(options.SourceKey))
+		options.SourceKey = s.Join(s.name, s.normalizeKey(options.SourceKey))
 		return options.DestinationBucket.Copy(ctx, options)
 	}
 
@@ -1277,7 +1291,7 @@ func (s *s3ArchiveBucket) Push(ctx context.Context, opts SyncOptions) error {
 		return errors.WithStack(err)
 	}
 
-	target := consistentJoin(opts.Remote, syncArchiveName)
+	target := s.Join(opts.Remote, syncArchiveName)
 
 	s3Writer, err := s.Writer(ctx, target)
 	if err != nil {
@@ -1327,7 +1341,7 @@ func (s *s3ArchiveBucket) Pull(ctx context.Context, opts SyncOptions) error {
 		}
 	}
 
-	target := consistentJoin(opts.Remote, syncArchiveName)
+	target := s.Join(opts.Remote, syncArchiveName)
 	reader, err := s.Get(ctx, target)
 	if err != nil {
 		return errors.Wrapf(err, "getting archive from remote path '%s'", opts.Remote)

--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -149,15 +149,7 @@ func CreateAWSCredentials(awsKey, awsPassword, awsToken string) *credentials.Cre
 	return credentials.NewStaticCredentials(awsKey, awsPassword, awsToken)
 }
 
-func (s *s3Bucket) normalizeKey(key string) string {
-	if key == "" {
-		return s.prefix
-	}
-	if s.prefix == "" {
-		return key
-	}
-	return s.Join(s.prefix, key)
-}
+func (s *s3Bucket) normalizeKey(key string) string { return s.Join(s.prefix, key) }
 
 func (s *s3Bucket) denormalizeKey(key string) string {
 	if s.prefix != "" && len(key) > len(s.prefix)+1 {

--- a/util.go
+++ b/util.go
@@ -98,13 +98,6 @@ func removeMatching(ctx context.Context, expression string, b Bucket) error {
 	return errors.Wrapf(b.RemoveMany(ctx, keys...), "deleting objects matching '%s'", expression)
 }
 
-func consistentJoin(prefix, key string) string {
-	if prefix != "" {
-		return prefix + "/" + key
-	}
-	return key
-}
-
 func deleteOnPush(ctx context.Context, sourceFiles []string, remote string, bucket Bucket) error {
 	sourceFilesMap := map[string]bool{}
 	for _, fn := range sourceFiles {


### PR DESCRIPTION
EVG-20170: https://jira.mongodb.org/browse/EVG-20170

Add new `Join` function to the `Bucket` interface that concatenates path elements with the appropriate path separator of the bucket.