### PR TITLE
DEVPROD-1448: list keys deterministically for all implementations (in lexicographical order)

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -705,6 +705,33 @@ func TestBucket(t *testing.T) {
 				assert.Nil(t, iter.Item())
 				assert.NoError(t, iter.Err())
 			})
+			t.Run("ListIteratesLexicographically", func(t *testing.T) {
+				bucket := impl.constructor(t)
+				keys := []string{
+					"0file",
+					"Afile",
+					"Zfile",
+					"afile1",
+					"cfile",
+					"zfile1",
+				}
+				// Insert keys in reverse order because some
+				// underlying bucket stores may iterate in
+				// insert order by default.
+				for i := len(keys) - 1; i >= 0; i-- {
+					assert.NoError(t, writeDataToFile(ctx, bucket, keys[i], "foo/bar"))
+				}
+
+				iter, err := bucket.List(ctx, "")
+				require.NoError(t, err)
+
+				var listedKeys []string
+				for iter.Next(ctx) {
+					listedKeys = append(listedKeys, iter.Item().Name())
+				}
+				require.NoError(t, iter.Err())
+				assert.Equal(t, keys, listedKeys)
+			})
 			t.Run("RoundTripManyFiles", func(t *testing.T) {
 				data := map[string]string{}
 				for i := 0; i < 3; i++ {

--- a/gridfs_bucket.go
+++ b/gridfs_bucket.go
@@ -497,7 +497,7 @@ func (b *gridfsBucket) List(ctx context.Context, prefix string) (BucketIterator,
 	if prefix != "" {
 		filter = bson.M{"filename": primitive.Regex{Pattern: fmt.Sprintf("^%s.*", b.normalizeKey(prefix))}}
 	}
-	cursor, err := grid.FindContext(ctx, filter)
+	cursor, err := grid.FindContext(ctx, filter, options.GridFSFind().SetSort(bson.M{"filename": 1}))
 	if err != nil {
 		return nil, errors.Wrap(err, "finding file")
 	}

--- a/interface.go
+++ b/interface.go
@@ -86,7 +86,7 @@ type Bucket interface {
 	// Note that this operation is not atomic.
 	RemoveMatching(context.Context, string) error
 
-	// List provides a way to iterator over the contents of a bucket with
+	// List returns an iterator over the contents of a bucket with the
 	// the given prefix. Contents are iterated lexicographically by key
 	// name.
 	List(context.Context, string) (BucketIterator, error)

--- a/interface.go
+++ b/interface.go
@@ -86,8 +86,9 @@ type Bucket interface {
 	// Note that this operation is not atomic.
 	RemoveMatching(context.Context, string) error
 
-	// List provides a way to iterator over the contents of a
-	// bucket with the given prefix.
+	// List provides a way to iterator over the contents of a bucket with
+	// the given prefix. Contents are iterated lexicographically by key
+	// name.
 	List(context.Context, string) (BucketIterator, error)
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DEVPROD-1448

- Update the GridFS implementation to sort filenames in ascending order
- Add a test to check that `List` iterates key names in lexicographical order