### PR TITLE
DEVPROD-3732: Path separator option for local pail bucket

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -204,6 +204,14 @@ func TestBucket(t *testing.T) {
 			},
 		},
 		{
+			name: "LocalSlashSeparator",
+			constructor: func(t *testing.T) Bucket {
+				path := filepath.Join(tempdir, uuid)
+				require.NoError(t, os.MkdirAll(path, 0777))
+				return &localFileSystem{path: path, prefix: testutil.NewUUID(), useSlash: true}
+			},
+		},
+		{
 			name: "S3Bucket",
 			constructor: func(t *testing.T) Bucket {
 				s3Options := S3Options{
@@ -303,6 +311,13 @@ func TestBucket(t *testing.T) {
 		},
 	} {
 		t.Run(impl.name, func(t *testing.T) {
+			// Only test local bucket with slash separator
+			// where the path separator is not the slash ('/')
+			// character.
+			if impl.name == "LocalSlashSeparator" && runtime.GOOS != "windows" {
+				t.Skip()
+			}
+
 			for _, test := range impl.tests {
 				t.Run(test.id, func(t *testing.T) {
 					bucket := impl.constructor(t)

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -311,9 +311,9 @@ func TestBucket(t *testing.T) {
 		},
 	} {
 		t.Run(impl.name, func(t *testing.T) {
-			// Only test local bucket with slash separator
-			// where the path separator is not the slash ('/')
-			// character.
+			// Only test the local implementation using the slash
+			// ('/') separator where the OS specific separator is
+			// different.
 			if impl.name == "LocalSlashSeparator" && runtime.GOOS != "windows" {
 				t.Skip()
 			}

--- a/local_bucket.go
+++ b/local_bucket.go
@@ -62,6 +62,7 @@ func NewLocalBucket(opts LocalOptions) (Bucket, error) {
 	b := &localFileSystem{
 		path:         opts.Path,
 		prefix:       opts.Prefix,
+		useSlash:     opts.UseSlash,
 		dryRun:       opts.DryRun,
 		deleteOnPush: opts.DeleteOnPush || opts.DeleteOnSync,
 		deleteOnPull: opts.DeleteOnPull || opts.DeleteOnSync,

--- a/local_bucket.go
+++ b/local_bucket.go
@@ -116,7 +116,7 @@ func (b *localFileSystem) Exists(_ context.Context, key string) (bool, error) {
 
 func (b *localFileSystem) Join(elems ...string) string {
 	if b.useSlash {
-		return consistentJoin(elems...)
+		return consistentJoin(elems)
 	}
 
 	return filepath.Join(elems...)


### PR DESCRIPTION
- Add a new option for local buckets `UseSlash` to override the OS specific path separator with the slash ('/') character.