### PR TITLE
DEVPROD-5544: fix consistent join

### DIFF
--- a/util.go
+++ b/util.go
@@ -15,14 +15,7 @@ import (
 )
 
 func consistentJoin(elems []string) string {
-	var out []string
-	for _, elem := range elems {
-		if elem != "" {
-			out = append(out, filepath.ToSlash(elem))
-		}
-	}
-
-	return strings.Join(out, "/")
+	return filepath.ToSlash(filepath.Join(elems...))
 }
 
 func consistentTrimPrefix(key, prefix string) string {


### PR DESCRIPTION
When joining path components consistently, need to make sure we are cleaning up the paths (e.g., replacing `//` with `/`).