### PR TITLE
DEVPROD-4713: use AWS config for assuming role

### DIFF
--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -123,10 +123,6 @@ type S3Options struct {
 	// `https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html` for
 	// more information. (Optional)
 	AssumeRoleARN string
-	// AssumeRoleRegion specifies the region to use for the assuming the
-	// AssumeRoleARN. If this is not set and AssumeRoleARN is set,
-	// AssumeRoleRegion will default to "us-east-1".
-	AssumeRoleRegion string
 	// AssumeRoleOptions provide a mechanism to override defaults by
 	// applying changes to the AssumeRoleProvider struct created with this
 	// session. This field is ignored if AssumeRoleARN is not set.
@@ -189,13 +185,7 @@ func newS3BucketBase(ctx context.Context, client *http.Client, options S3Options
 		})
 	} else if options.AssumeRoleARN != "" {
 		s3Opts = append(s3Opts, func(opts *s3.Options) {
-			region := options.AssumeRoleRegion
-			if region == "" {
-				region = "us-east-1"
-			}
-			assumeRoleClient := sts.New(sts.Options{
-				Region: region,
-			})
+			assumeRoleClient := sts.NewFromConfig(*cfg)
 			opts.Credentials = stscreds.NewAssumeRoleProvider(assumeRoleClient, options.AssumeRoleARN, options.AssumeRoleOptions...)
 		})
 	}

--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -123,6 +123,10 @@ type S3Options struct {
 	// `https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html` for
 	// more information. (Optional)
 	AssumeRoleARN string
+	// AssumeRoleRegion specifies the region to use for the assuming the
+	// AssumeRoleARN. If this is not set and AssumeRoleARN is set,
+	// AssumeRoleRegion will default to "us-east-1".
+	AssumeRoleRegion string
 	// AssumeRoleOptions provide a mechanism to override defaults by
 	// applying changes to the AssumeRoleProvider struct created with this
 	// session. This field is ignored if AssumeRoleARN is not set.
@@ -185,7 +189,13 @@ func newS3BucketBase(ctx context.Context, client *http.Client, options S3Options
 		})
 	} else if options.AssumeRoleARN != "" {
 		s3Opts = append(s3Opts, func(opts *s3.Options) {
-			assumeRoleClient := sts.New(sts.Options{})
+			region := options.AssumeRoleRegion
+			if region == "" {
+				region = "us-east-1"
+			}
+			assumeRoleClient := sts.New(sts.Options{
+				Region: region,
+			})
 			opts.Credentials = stscreds.NewAssumeRoleProvider(assumeRoleClient, options.AssumeRoleARN, options.AssumeRoleOptions...)
 		})
 	}


### PR DESCRIPTION
Fixes a small bug in #112 with how it assumes an IAM role to access the S3 bucket. Before #112,  the logic for assuming a role [shared the same AWS config that S3 uses](https://github.com/evergreen-ci/pail/blob/b600c21b5f20c2eddd597267e27a32fe1d7211f0/s3_bucket.go#L196). Reusing the config implicitly set the AWS region where the role was being assumed (the region is required to assume a role). This amends #112 so that it once again assumes a role with the shared config.

This only matters for Cedar, which assumes a role for some of its S3 buckets. Evergreen never assumes a role to access S3 buckets.