### PR TITLE
DEVPROD-3611: upgrade Go version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,13 +3,8 @@ linters:
   disable-all: true
   enable:
     - errcheck
-    - gofmt
     - goimports
     - govet
     - ineffassign
     - misspell
     - unconvert
-
-linters-settings:
-  govet:
-    check-shadowing: false

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -122,7 +122,7 @@ buildvariants:
   - name: lint
     display_name: Lint
     expansions:
-      GOROOT: /opt/golang/go1.20
+      GOROOT: /opt/golang/go1.24
       MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.6.tgz
       MONGOSH_URL: https://downloads.mongodb.com/compass/mongosh-1.9.0-linux-x64.tgz
     run_on:
@@ -134,7 +134,7 @@ buildvariants:
   - name: ubuntu
     display_name: Ubuntu 22.04
     expansions:
-      GOROOT: /opt/golang/go1.20
+      GOROOT: /opt/golang/go1.24
       MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.6.tgz
       MONGOSH_URL: https://downloads.mongodb.com/compass/mongosh-1.9.0-linux-x64.tgz
       RACE_DETECTOR: true
@@ -146,7 +146,7 @@ buildvariants:
   - name: macos
     display_name: macOS
     expansions:
-      GOROOT: /opt/golang/go1.20
+      GOROOT: /opt/golang/go1.24
       MONGODB_URL: https://fastdl.mongodb.org/osx/mongodb-macos-arm64-6.0.6.tgz
       MONGOSH_URL: https://downloads.mongodb.com/compass/mongosh-1.9.0-darwin-arm64.zip
       MONGOSH_DECOMPRESS: unzip
@@ -160,7 +160,7 @@ buildvariants:
     run_on:
       - windows-vsCurrent-small
     expansions:
-      GOROOT: C:/golang/go1.20
+      GOROOT: C:/golang/go1.24
       MONGODB_URL: https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-6.0.6.zip
       MONGOSH_URL: https://downloads.mongodb.com/compass/mongosh-1.9.0-win32-x64.zip
     tasks:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/evergreen-ci/pail
 
-go 1.20
+go 1.24
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.3

--- a/makefile
+++ b/makefile
@@ -56,7 +56,7 @@ $(shell mkdir -p $(buildDir))
 
 # start lint setup targets
 $(buildDir)/golangci-lint:
-	@curl --retry 10 --retry-max-time 60 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(buildDir) v1.51.2 >/dev/null 2>&1
+	@curl --retry 10 --retry-max-time 60 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(buildDir) v1.64.5 >/dev/null 2>&1
 $(buildDir)/run-linter: cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	@$(gobin) build -o $@ $<
 # end lint setup targets


### PR DESCRIPTION
* Upgrade to Go 1.24.
* Upgrade golangci-lint to support Go 1.24.
* Remove some old linters that are now invalid.