### PR TITLE
DEVPROD-13979 Add AssumeRole credentials option and provider

### DIFF
--- a/benchmarks/harness.go
+++ b/benchmarks/harness.go
@@ -333,7 +333,7 @@ func makeLocalTree(numFiles int, bytesPerFile int) makePayload {
 
 func s3Opts() pail.S3Options {
 	return pail.S3Options{
-		Credentials: pail.CreateAWSCredentials(os.Getenv("AWS_KEY"), os.Getenv("AWS_SECRET"), ""),
+		Credentials: pail.CreateAWSStaticCredentials(os.Getenv("AWS_KEY"), os.Getenv("AWS_SECRET"), ""),
 		Region:      "us-east-1",
 		Name:        "build-test-curator",
 		Prefix:      testutil.NewUUID(),

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -45,7 +45,7 @@ func TestBucket(t *testing.T) {
 	tempdir := t.TempDir()
 	require.NoError(t, err, os.MkdirAll(filepath.Join(tempdir, uuid), 0700))
 
-	s3Credentials := CreateAWSCredentials(os.Getenv("AWS_KEY"), os.Getenv("AWS_SECRET"), "")
+	s3Credentials := CreateAWSStaticCredentials(os.Getenv("AWS_KEY"), os.Getenv("AWS_SECRET"), "")
 	s3BucketName := "build-test-curator"
 	s3Prefix := testutil.NewUUID() + "-"
 	s3Region := "us-east-1"
@@ -1148,7 +1148,7 @@ func TestS3ArchiveBucket(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, os.RemoveAll(tempdir)) }()
 
-	s3Credentials := CreateAWSCredentials(os.Getenv("AWS_KEY"), os.Getenv("AWS_SECRET"), "")
+	s3Credentials := CreateAWSStaticCredentials(os.Getenv("AWS_KEY"), os.Getenv("AWS_SECRET"), "")
 	s3BucketName := "build-test-curator"
 	s3Prefix := testutil.NewUUID() + "-"
 	s3Region := "us-east-1"
@@ -1552,7 +1552,7 @@ func TestPreSign(t *testing.T) {
 
 	awsKey := os.Getenv("AWS_KEY")
 	awsSecret := os.Getenv("AWS_SECRET")
-	s3Credentials := CreateAWSCredentials(awsKey, awsSecret, "")
+	s3Credentials := CreateAWSStaticCredentials(awsKey, awsSecret, "")
 	s3BucketName := "build-test-curator"
 	s3Prefix := testutil.NewUUID() + "-"
 	s3Object := testutil.NewUUID()
@@ -1573,8 +1573,8 @@ func TestPreSign(t *testing.T) {
 	require.NoError(t, b.Put(ctx, s3Object, strings.NewReader(data)))
 
 	req := PreSignRequestParams{
-		AwsKey:    awsKey,
-		AwsSecret: awsSecret,
+		AWSKey:    awsKey,
+		AWSSecret: awsSecret,
 		Region:    s3Region,
 		Bucket:    s3BucketName,
 		FileKey:   consistentJoin([]string{s3Prefix, s3Object}),
@@ -1600,7 +1600,7 @@ func TestGetHeadObject(t *testing.T) {
 
 	awsKey := os.Getenv("AWS_KEY")
 	awsSecret := os.Getenv("AWS_SECRET")
-	s3Credentials := CreateAWSCredentials(awsKey, awsSecret, "")
+	s3Credentials := CreateAWSStaticCredentials(awsKey, awsSecret, "")
 	s3BucketName := "build-test-curator"
 	s3Prefix := testutil.NewUUID() + "-"
 	s3Object := testutil.NewUUID()
@@ -1625,8 +1625,8 @@ func TestGetHeadObject(t *testing.T) {
 
 	t.Run("FailsWithNonexistentObject", func(t *testing.T) {
 		req := PreSignRequestParams{
-			AwsKey:    awsKey,
-			AwsSecret: awsSecret,
+			AWSKey:    awsKey,
+			AWSSecret: awsSecret,
 			Region:    s3Region,
 			Bucket:    s3BucketName,
 			FileKey:   consistentJoin([]string{s3Prefix, "DNE"}),
@@ -1638,8 +1638,8 @@ func TestGetHeadObject(t *testing.T) {
 
 	t.Run("SucceedsWithExistingObject", func(t *testing.T) {
 		req := PreSignRequestParams{
-			AwsKey:    awsKey,
-			AwsSecret: awsSecret,
+			AWSKey:    awsKey,
+			AWSSecret: awsSecret,
 			Region:    s3Region,
 			Bucket:    s3BucketName,
 			FileKey:   consistentJoin([]string{s3Prefix, s3Object}),

--- a/s3_bucket_util_test.go
+++ b/s3_bucket_util_test.go
@@ -42,7 +42,7 @@ func getS3SmallBucketTests(ctx context.Context, tempdir string, s3Credentials aw
 				assert.NoError(t, err)
 
 				badOptions := S3Options{
-					Credentials: CreateAWSCredentials("asdf", "asdf", "asdf"),
+					Credentials: CreateAWSStaticCredentials("asdf", "asdf", "asdf"),
 					Region:      s3Region,
 					Name:        s3BucketName,
 				}
@@ -369,7 +369,7 @@ func getS3LargeBucketTests(ctx context.Context, tempdir string, s3Credentials aw
 				assert.NoError(t, err)
 
 				badOptions := S3Options{
-					Credentials: CreateAWSCredentials("asdf", "asdf", "asdf"),
+					Credentials: CreateAWSStaticCredentials("asdf", "asdf", "asdf"),
 					Region:      s3Region,
 					Name:        s3BucketName,
 				}


### PR DESCRIPTION
[DEVPROD-13979](https://jira.mongodb.org/browse/DEVPROD-13979)

This adds an `AWSRoleARN` option to the provider options. This is to support presigning with AssumeRole easier.

This prepares the above ticket for the Evergreen change.