### PR TITLE
DEVPROD-16093: add S3Bucket interface for faster downloads

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -92,6 +92,17 @@ type Bucket interface {
 	List(context.Context, string) (BucketIterator, error)
 }
 
+// FastGetS3Bucket is a Bucket but with an additional method, GetToWriter. Only S3
+// bucket types can support this access pattern.
+type FastGetS3Bucket interface {
+	Bucket
+	// GetToWriter allows the user to pass in an io.WriterAt (which is likely
+	// going to be a file) that has the contents of the remote key automatically
+	// copied to it in parallel. GetToWriter is significantly more efficient for
+	// large files than a Bucket.Get.
+	GetToWriter(context.Context, string, io.WriterAt) error
+}
+
 // SyncBucket defines an interface to access a remote blob store and synchronize
 // the local file system tree with the remote store.
 type SyncBucket interface {


### PR DESCRIPTION
This commit adds a new interface, S3Bucket, which is a pail.Bucket but with one additional method, GetTo. GetTo allows the caller to pass in an io.WriterAt which will have the contents of the object automatically copied to it. This method was added to add support for AWS' official S3Manager.Download API. This API is significantly more efficient for large files than the s3.Client.GetObject() API alone because it uses byte ranges to fetch parts of the object in parallel.

In local tests of a 35GB file I observed download times go from 25 to 7 minutes. Even tests of smaller files consistently show improved download times.

I chose to make a new interface because I did not want to potentially break any users of the Bucket interface, and adding support to the other Bucket implementations felt pretty tricky and not worthwhile. Because our constructors are returning an interface instead of a struct, it was necessary to add a new constructor which returned this new interface. I'm not really in love with this approach, but it's the safest for backward compatibility given the current API of Pail.

I have included a test of this new behavior within the existing test fixtures.