### PR TITLE
DEVPROD-17133: correctly close gzip buffer on put

### DIFF
--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -769,6 +769,10 @@ func putHelper(ctx context.Context, b *s3Bucket, key string, r io.Reader) error 
 			return errors.Wrap(err, "gzipping file")
 		}
 
+		if err := w.Close(); err != nil {
+			return errors.Wrap(err, "closing gzip writer")
+		}
+
 		r = bytes.NewReader(buf.Bytes())
 	}
 


### PR DESCRIPTION
This commit fixes a bug when Compress: true was passed to pail where we forgot to close the gzip writer. This bug was introduced in 10686cd7fb4e407b49a2099d769331646b6fa372. The tests did not catch this mistake because we were only testing the write path through .Writer instead of .Put. This commit also adds a test for Put which uses compression. Without the corresponding change to s3_bucket.go, this test case will fail as expected.