### PR TITLE
DEVPROD-15694 Add a mutex to the cross-goroutine aws config cache

### DIFF
--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -245,7 +245,8 @@ func getCachedConfig(ctx context.Context, cfgOpts configOpts) (*aws.Config, erro
 		cfgOpts.sharedCredentialsProfile == ""
 	// We completely lock the mutex to ensure that we do not create multiple
 	// configurations. This locks it for this read and later in this function
-	// when we write the new configuration to the cache.
+	// when we write the new configuration to the cache. This effectively
+	// makes reading + writing atomic.
 	awsConfigs.mutex.Lock()
 	defer awsConfigs.mutex.Unlock()
 	if isDefault && awsConfigs.cache[cfgOpts] != nil {


### PR DESCRIPTION
[DEVPROD-15694](https://jira.mongodb.org/browse/DEVPROD-15694)

# Description

This adds a mutex to the aws config cache