### PR TITLE
DEVPROD-27407: Track Actual Number of S3 Puts for Artifacts and Streaming Uploads to AWS

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -93,10 +93,22 @@ type Bucket interface {
 
 	// String returns the bucket name.
 	String() string
-	
+
 	// MoveObjects moves multiple objects from sourceKeys in this bucket to destKeys in another bucket specified by destBucket.
 	// The lengths of sourceKeys and destKeys must match.
 	MoveObjects(ctx context.Context, destBucket Bucket, sourceKeys, destKeys []string) error
+}
+
+// PutCounter is an optional interface implemented by S3 buckets that returns the number of PUT-equivalent API calls made per upload.
+type PutCounter interface {
+	Bucket
+	UploadWithCount(ctx context.Context, key, path string) (int, error)
+}
+
+// StreamPutCounter is an optional interface implemented by S3 buckets that returns the number of PUT-equivalent API calls made when streaming content to S3.
+type StreamPutCounter interface {
+	Bucket
+	PutWithCount(ctx context.Context, key string, r io.Reader) (int, error)
 }
 
 // FastGetS3Bucket is a Bucket but with an additional method, GetToWriter. Only S3

--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -892,11 +892,13 @@ func (c *countingS3Client) CompleteMultipartUpload(ctx context.Context, in *s3.C
 	return out, err
 }
 
-// isAWSServiceError returns true if err came from AWS (the request reached the service and
-// AWS responded with an error). Network failures that never reached AWS return false.
+// isAWSServiceError returns true if err is a server-side AWS error (5xx). Server-side errors
+// mean AWS accepted and processed the request, which counts as a billable API call. Client
+// errors (4xx, including 401 and 403) indicate the request was rejected before any operation
+// ran and are not billed by AWS.
 func isAWSServiceError(err error) bool {
 	var apiErr smithy.APIError
-	return errors.As(err, &apiErr)
+	return errors.As(err, &apiErr) && apiErr.ErrorFault() == smithy.FaultServer
 }
 
 // putHelper uploads r to key and returns the number of S3 PUT-equivalent API calls made.

--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 
@@ -71,9 +72,9 @@ type s3BucketLarge struct {
 }
 
 type s3Bucket struct {
-	dryRun              bool
-	deleteOnPush        bool
-	deleteOnPull        bool
+	dryRun       bool
+	deleteOnPush bool
+	deleteOnPull bool
 	// expectedChecksumSHA256 checks on downloads that the SHA256 checksum
 	// matches the expected value.
 	expectedChecksumSHA256 string
@@ -88,10 +89,10 @@ type s3Bucket struct {
 	name                 string
 	prefix               string
 	// versionID pins download operations to a specific S3 object version.
-	versionID   string
-	permissions S3Permissions
-	contentType string
-	storageClass         s3Types.StorageClass
+	versionID    string
+	permissions  S3Permissions
+	contentType  string
+	storageClass s3Types.StorageClass
 }
 
 // S3Options support the use and creation of S3 backed buckets.
@@ -852,9 +853,57 @@ func (s *s3Bucket) Reader(ctx context.Context, key string) (io.ReadCloser, error
 	return result.Body, nil
 }
 
-func putHelper(ctx context.Context, b *s3Bucket, key string, r io.Reader) error {
+// countingS3Client wraps an S3 upload client to count each API call that AWS bills as a
+// PUT-equivalent request. It implements s3Manager.UploadAPIClient.
+type countingS3Client struct {
+	s3Manager.UploadAPIClient
+	count *atomic.Int32
+}
+
+func (c *countingS3Client) PutObject(ctx context.Context, in *s3.PutObjectInput, opts ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	out, err := c.UploadAPIClient.PutObject(ctx, in, opts...)
+	if err == nil || isAWSServiceError(err) {
+		c.count.Add(1)
+	}
+	return out, err
+}
+
+func (c *countingS3Client) CreateMultipartUpload(ctx context.Context, in *s3.CreateMultipartUploadInput, opts ...func(*s3.Options)) (*s3.CreateMultipartUploadOutput, error) {
+	out, err := c.UploadAPIClient.CreateMultipartUpload(ctx, in, opts...)
+	if err == nil || isAWSServiceError(err) {
+		c.count.Add(1)
+	}
+	return out, err
+}
+
+func (c *countingS3Client) UploadPart(ctx context.Context, in *s3.UploadPartInput, opts ...func(*s3.Options)) (*s3.UploadPartOutput, error) {
+	out, err := c.UploadAPIClient.UploadPart(ctx, in, opts...)
+	if err == nil || isAWSServiceError(err) {
+		c.count.Add(1)
+	}
+	return out, err
+}
+
+func (c *countingS3Client) CompleteMultipartUpload(ctx context.Context, in *s3.CompleteMultipartUploadInput, opts ...func(*s3.Options)) (*s3.CompleteMultipartUploadOutput, error) {
+	out, err := c.UploadAPIClient.CompleteMultipartUpload(ctx, in, opts...)
+	if err == nil || isAWSServiceError(err) {
+		c.count.Add(1)
+	}
+	return out, err
+}
+
+// isAWSServiceError returns true if err came from AWS (the request reached the service and
+// AWS responded with an error). Network failures that never reached AWS return false.
+func isAWSServiceError(err error) bool {
+	var apiErr smithy.APIError
+	return errors.As(err, &apiErr)
+}
+
+// putHelper uploads r to key and returns the number of S3 PUT-equivalent API calls made.
+// The count is returned even on error because calls that reached AWS are billed.
+func putHelper(ctx context.Context, b *s3Bucket, key string, r io.Reader) (int, error) {
 	if b.dryRun {
-		return nil
+		return 0, nil
 	}
 
 	if b.compress {
@@ -863,17 +912,18 @@ func putHelper(ctx context.Context, b *s3Bucket, key string, r io.Reader) error 
 		w := gzip.NewWriter(&buf)
 
 		if _, err := io.Copy(w, r); err != nil {
-			return errors.Wrap(err, "gzipping file")
+			return 0, errors.Wrap(err, "gzipping file")
 		}
 
 		if err := w.Close(); err != nil {
-			return errors.Wrap(err, "closing gzip writer")
+			return 0, errors.Wrap(err, "closing gzip writer")
 		}
 
 		r = bytes.NewReader(buf.Bytes())
 	}
 
-	uploader := s3Manager.NewUploader(b.svc)
+	var putCount atomic.Int32
+	uploader := s3Manager.NewUploader(&countingS3Client{UploadAPIClient: b.svc, count: &putCount})
 	uploader.Concurrency = getManagerConcurrency()
 
 	key = b.normalizeKey(key)
@@ -906,12 +956,8 @@ func putHelper(ctx context.Context, b *s3Bucket, key string, r io.Reader) error 
 		input.ContentEncoding = aws.String(compressionEncoding)
 	}
 
-	if _, err := uploader.Upload(ctx, input); err != nil {
-		return errors.Wrapf(err, "uploading file")
-	}
-
-	return nil
-
+	_, err := uploader.Upload(ctx, input)
+	return int(putCount.Load()), errors.Wrapf(err, "uploading file")
 }
 
 func (s *s3BucketSmall) Put(ctx context.Context, key string, r io.Reader) error {
@@ -924,7 +970,8 @@ func (s *s3BucketSmall) Put(ctx context.Context, key string, r io.Reader) error 
 		"key":           key,
 	})
 
-	return putHelper(ctx, &s.s3Bucket, key, r)
+	_, err := putHelper(ctx, &s.s3Bucket, key, r)
+	return err
 }
 
 func (s *s3BucketLarge) Put(ctx context.Context, key string, r io.Reader) error {
@@ -937,7 +984,8 @@ func (s *s3BucketLarge) Put(ctx context.Context, key string, r io.Reader) error 
 		"key":           key,
 	})
 
-	return putHelper(ctx, &s.s3Bucket, key, r)
+	_, err := putHelper(ctx, &s.s3Bucket, key, r)
+	return err
 }
 
 func (s *s3Bucket) Get(ctx context.Context, key string) (io.ReadCloser, error) {
@@ -1026,7 +1074,13 @@ func doUpload(ctx context.Context, b Bucket, key, path string) error {
 	return errors.WithStack(b.Put(ctx, key, f))
 }
 
-func (s *s3Bucket) uploadHelper(ctx context.Context, b Bucket, key, path string) error {
+func (s *s3Bucket) Upload(ctx context.Context, key, path string) error {
+	_, err := s.UploadWithCount(ctx, key, path)
+	return err
+}
+
+// UploadWithCount uploads path to key; returns the PUT count even on error since calls that reached AWS are billed.
+func (s *s3Bucket) UploadWithCount(ctx context.Context, key, path string) (int, error) {
 	grip.DebugWhen(ctx, s.verbose, message.Fields{
 		"type":          "s3",
 		"dry_run":       s.dryRun,
@@ -1037,15 +1091,26 @@ func (s *s3Bucket) uploadHelper(ctx context.Context, b Bucket, key, path string)
 		"path":          path,
 	})
 
-	return errors.WithStack(doUpload(ctx, b, key, path))
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, errors.Wrapf(err, "opening file '%s'", path)
+	}
+	defer f.Close()
+
+	return putHelper(ctx, s, key, f)
 }
 
-func (s *s3BucketLarge) Upload(ctx context.Context, key, path string) error {
-	return s.uploadHelper(ctx, s, key, path)
-}
-
-func (s *s3BucketSmall) Upload(ctx context.Context, key, path string) error {
-	return s.uploadHelper(ctx, s, key, path)
+// PutWithCount streams r to key; returns the PUT count even on error since calls that reached AWS are billed.
+func (s *s3Bucket) PutWithCount(ctx context.Context, key string, r io.Reader) (int, error) {
+	grip.DebugWhen(ctx, s.verbose, message.Fields{
+		"type":          "s3",
+		"dry_run":       s.dryRun,
+		"operation":     "put",
+		"bucket":        s.name,
+		"bucket_prefix": s.prefix,
+		"key":           key,
+	})
+	return putHelper(ctx, s, key, r)
 }
 
 func doDownload(ctx context.Context, b Bucket, key, path string) error {

--- a/s3_bucket_util_test.go
+++ b/s3_bucket_util_test.go
@@ -1189,3 +1189,50 @@ func makeMoveObjectsWithXMLIncompatibleCharsTest(ctx context.Context, s3Credenti
 		}
 	}
 }
+
+func TestPutHelperDryRunReturnsZeroPuts(t *testing.T) {
+	ctx := t.Context()
+	b := &s3Bucket{dryRun: true}
+	n, err := putHelper(ctx, b, "key", bytes.NewReader([]byte("data")))
+	assert.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestS3BucketImplementsPutCounter(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "src.txt")
+	require.NoError(t, os.WriteFile(srcPath, []byte("hello"), 0600))
+
+	small := &s3BucketSmall{s3Bucket: s3Bucket{dryRun: true}}
+	large := &s3BucketLarge{s3Bucket: s3Bucket{dryRun: true}}
+
+	var _ PutCounter = small
+	var _ PutCounter = large
+
+	n, err := small.UploadWithCount(ctx, "key", srcPath)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	n, err = large.UploadWithCount(ctx, "key", srcPath)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestS3BucketImplementsStreamPutCounter(t *testing.T) {
+	ctx := t.Context()
+
+	small := &s3BucketSmall{s3Bucket: s3Bucket{dryRun: true}}
+	large := &s3BucketLarge{s3Bucket: s3Bucket{dryRun: true}}
+
+	var _ StreamPutCounter = small
+	var _ StreamPutCounter = large
+
+	n, err := small.PutWithCount(ctx, "key", bytes.NewReader([]byte("hello")))
+	assert.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	n, err = large.PutWithCount(ctx, "key", bytes.NewReader([]byte("hello")))
+	assert.NoError(t, err)
+	assert.Equal(t, 0, n)
+}

--- a/s3_bucket_util_test.go
+++ b/s3_bucket_util_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -18,6 +19,7 @@ import (
 	s3Manager "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3Types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 	"github.com/evergreen-ci/pail/testutil"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/stretchr/testify/assert"
@@ -1217,6 +1219,13 @@ func TestS3BucketImplementsPutCounter(t *testing.T) {
 	n, err = large.UploadWithCount(ctx, "key", srcPath)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, n)
+}
+
+func TestIsAWSServiceError(t *testing.T) {
+	assert.False(t, isAWSServiceError(nil))
+	assert.False(t, isAWSServiceError(errors.New("connection refused")))
+	assert.False(t, isAWSServiceError(&smithy.GenericAPIError{Code: "InvalidAccessKeyId", Fault: smithy.FaultClient}))
+	assert.True(t, isAWSServiceError(&smithy.GenericAPIError{Code: "InternalError", Fault: smithy.FaultServer}))
 }
 
 func TestS3BucketImplementsStreamPutCounter(t *testing.T) {


### PR DESCRIPTION
DEVPROD-27407

### Description
Currently there is no accurate way to count the number of PUT requests that reach AWS. This PR adds counters for S3 Artifact and streaming put that will enable counting all PUT requests that have reached AWS. This will enable as accurate as possible bill metrics.

Once this is merged, an evergreen-app will follow to incorporate these changes
### Testing
Testing in staging along with evergreen-app changes
