### PR TITLE
DEVPROD-34338 Fix CopyObject NoSuchKey for S3 keys containing '+'

### DIFF
--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1276,11 +1275,11 @@ func (s *s3Bucket) Copy(ctx context.Context, options CopyOptions) error {
 		"dest_key":      options.DestinationKey,
 	})
 
-	// CopySource must be URL-encoded to handle special characters (including control characters)
-	// that are invalid in HTTP header values.
+	// CopySource must percent-encode '+' and bytes outside printable ASCII (space,
+	// control characters, DEL, and high bytes). S3 interprets a literal '+' as a space.
 	input := &s3.CopyObjectInput{
 		Bucket:     aws.String(s.name),
-		CopySource: aws.String(url.PathEscape(options.SourceKey)),
+		CopySource: aws.String(escapeCopySource(options.SourceKey)),
 		Key:        aws.String(s.normalizeKey(options.DestinationKey)),
 		ACL:        s3Types.ObjectCannedACL(string(s.permissions)),
 	}
@@ -1292,6 +1291,25 @@ func (s *s3Bucket) Copy(ctx context.Context, options CopyOptions) error {
 		}
 	}
 	return nil
+}
+
+// escapeCopySource encodes '+' as '%2B' (S3 interprets literal '+' as a space in
+// CopySource), and percent-encodes space, control characters, DEL (0x7F), and high
+// bytes (>=0x80). Other printable ASCII, including '/', is left as-is.
+func escapeCopySource(s string) string {
+	const hextable = "0123456789ABCDEF"
+	var buf strings.Builder
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if b == '+' || b <= 0x20 || b == 0x7F || b > 0x7E {
+			buf.WriteByte('%')
+			buf.WriteByte(hextable[b>>4])
+			buf.WriteByte(hextable[b&0x0F])
+		} else {
+			buf.WriteByte(b)
+		}
+	}
+	return buf.String()
 }
 
 func (s *s3Bucket) Remove(ctx context.Context, key string) error {

--- a/util_test.go
+++ b/util_test.go
@@ -119,3 +119,77 @@ func TestTarFile(t *testing.T) {
 		})
 	}
 }
+
+func TestEscapeCopySource(t *testing.T) {
+	for testName, tc := range map[string]struct {
+		input    string
+		expected string
+	}{
+		"EmptyStringReturnsEmpty": {
+			input:    "",
+			expected: "",
+		},
+		"PlainAlphanumericUnchanged": {
+			input:    "mybucket/project/task/0/task_logs/agent/chunk",
+			expected: "mybucket/project/task/0/task_logs/agent/chunk",
+		},
+		// '+' must be encoded as '%2B': S3 applies form-encoding semantics to the
+		// CopySource header and interprets a literal '+' as a space, causing NoSuchKey
+		// for objects whose keys contain a literal '+'.
+		"PlusSignEncodedAsPercent2B": {
+			input:    "mybucket/myproject/task_+_variant/0/task_logs/system/chunk",
+			expected: "mybucket/myproject/task_%2B_variant/0/task_logs/system/chunk",
+		},
+		"ForwardSlashNotEncoded": {
+			input:    "mybucket/prefix/key/with/slashes",
+			expected: "mybucket/prefix/key/with/slashes",
+		},
+		"TildeNotEncoded": {
+			input:    "mybucket/key~with~tildes",
+			expected: "mybucket/key~with~tildes",
+		},
+		"HyphenAndUnderscoreNotEncoded": {
+			input:    "mybucket/key-with_hyphens_and-underscores",
+			expected: "mybucket/key-with_hyphens_and-underscores",
+		},
+		"SpaceEncoded": {
+			input:    "mybucket/key with spaces",
+			expected: "mybucket/key%20with%20spaces",
+		},
+		"TabEncoded": {
+			input:    "mybucket/key\twith\ttabs",
+			expected: "mybucket/key%09with%09tabs",
+		},
+		"NewlineEncoded": {
+			input:    "mybucket/key\nwith\nnewlines",
+			expected: "mybucket/key%0Awith%0Anewlines",
+		},
+		"CarriageReturnEncoded": {
+			input:    "mybucket/key\rwith\rCR",
+			expected: "mybucket/key%0Dwith%0DCR",
+		},
+		"NullByteEncoded": {
+			input:    "mybucket/key\x00with\x00nulls",
+			expected: "mybucket/key%00with%00nulls",
+		},
+		"DELEncoded": {
+			input:    "mybucket/key\x7fwith\x7fdel",
+			expected: "mybucket/key%7Fwith%7Fdel",
+		},
+		"NonASCIIEncoded": {
+			input:    "mybucket/key\x80\xFF",
+			expected: "mybucket/key%80%FF",
+		},
+		// Realistic key path: long task ID containing both '+' and '~' with multiple
+		// path segments, matching the format used for task log chunk keys.
+		// '+' is encoded; '~' (RFC 3986 unreserved) is left as-is.
+		"LongTaskKeyPathWithPlusAndTilde": {
+			input:    "mybucket/myproject/mytask_+_myvariant__param~value/0/task_logs/system/0_100_200_50_300",
+			expected: "mybucket/myproject/mytask_%2B_myvariant__param~value/0/task_logs/system/0_100_200_50_300",
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, tc.expected, escapeCopySource(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
 [DEVPROD-34338](https://jira.mongodb.org/browse/DEVPROD-34338)
 
 
S3 interprets a literal + in the x-amz-copy-source header as a space, so CopyObject returns NoSuchKey for any object whose key contains + even though the object exists. url.PathEscape (which was already in use) does not encode +. This was causing logs for some tasks to get stuck in the success bucket when they should be in the failed bucked because it would error with NoSuchKey every time the job tried to move it. 

This replaces url.PathEscape with escapeCopySource, which encodes + as %2B so S3 resolves it to a literal + during key lookup. Control characters and non-ASCII bytes (invalid in HTTP headers) are also encoded; all other printable ASCII is left as-is. 