### PR TITLE
DEVPROD-33022: Add Size field to BucketItem interface to get Log Chunks size for S3 Calculations

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -665,14 +665,18 @@ func TestBucket(t *testing.T) {
 			t.Run("ListRespectsPrefixes", func(t *testing.T) {
 				bucket := impl.constructor(t)
 				key := testutil.NewUUID()
+				content := "foo/bar"
 
-				assert.NoError(t, writeDataToFile(ctx, bucket, key, "foo/bar"))
+				assert.NoError(t, writeDataToFile(ctx, bucket, key, content))
 
 				// There's one thing in the iterator with the
 				// correct prefix.
 				iter, err := bucket.List(ctx, "")
 				require.NoError(t, err)
-				assert.True(t, iter.Next(ctx))
+				require.True(t, iter.Next(ctx))
+				item := iter.Item()
+				require.NotNil(t, item)
+				assert.Equal(t, int64(len(content)), item.Size())
 				assert.False(t, iter.Next(ctx))
 				assert.NoError(t, iter.Err())
 

--- a/gridfs_bucket.go
+++ b/gridfs_bucket.go
@@ -527,6 +527,7 @@ func (iter *gridfsIterator) Next(ctx context.Context) bool {
 	document := struct {
 		ID       interface{} `bson:"_id"`
 		Filename string      `bson:"filename"`
+		Length   int64       `bson:"length"`
 	}{}
 	if err := iter.iter.Decode(&document); err != nil {
 		iter.err = err
@@ -537,6 +538,7 @@ func (iter *gridfsIterator) Next(ctx context.Context) bool {
 		bucket: iter.bucket.opts.Name,
 		key:    iter.bucket.denormalizeKey(document.Filename),
 		b:      iter.bucket,
+		size:   document.Length,
 	}
 	return true
 }

--- a/interface.go
+++ b/interface.go
@@ -172,6 +172,8 @@ type BucketItem interface {
 	Bucket() string
 	Name() string
 	Hash() string
+	// Size returns the object size in bytes.
+	Size() int64
 	Get(context.Context) (io.ReadCloser, error)
 }
 
@@ -179,6 +181,7 @@ type bucketItemImpl struct {
 	bucket string
 	key    string
 	hash   string
+	size   int64
 
 	// TODO add other info?
 
@@ -191,6 +194,7 @@ type bucketItemImpl struct {
 func (bi *bucketItemImpl) Name() string   { return bi.key }
 func (bi *bucketItemImpl) Hash() string   { return bi.hash }
 func (bi *bucketItemImpl) Bucket() string { return bi.bucket }
+func (bi *bucketItemImpl) Size() int64    { return bi.size }
 func (bi *bucketItemImpl) Get(ctx context.Context) (io.ReadCloser, error) {
 	return bi.b.Get(ctx, bi.key)
 }

--- a/local_bucket.go
+++ b/local_bucket.go
@@ -537,9 +537,16 @@ func (iter *localFileSystemIterator) Next(_ context.Context) bool {
 		return false
 	}
 
+	key := iter.bucket.Join(iter.prefix, iter.files[iter.idx])
+	physPath := iter.bucket.Join(iter.bucket.path, iter.bucket.normalizeKey(key))
+	var size int64
+	if info, err := os.Stat(physPath); err == nil {
+		size = info.Size()
+	}
 	iter.item = &bucketItemImpl{
 		bucket: iter.bucket.path,
-		key:    iter.bucket.Join(iter.prefix, iter.files[iter.idx]),
+		key:    key,
+		size:   size,
 		b:      iter.bucket,
 	}
 	return true

--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -1674,10 +1674,15 @@ func (iter *s3BucketIterator) Next(ctx context.Context) bool {
 		}
 	}
 
+	size := int64(0)
+	if iter.contents[iter.idx].Size != nil {
+		size = *iter.contents[iter.idx].Size
+	}
 	iter.item = &bucketItemImpl{
 		bucket: iter.s.name,
 		key:    iter.s.denormalizeKey(*iter.contents[iter.idx].Key),
 		hash:   strings.Trim(*iter.contents[iter.idx].ETag, `"`),
+		size:   size,
 		b:      iter.b,
 	}
 	return true


### PR DESCRIPTION
Adding a size field the BucketItem interface. This get populated from the S3 ListObjectsV2 response for S3 buckets. This gives us the size of log chunks store in S3 that can be used to calculate logs sizes in for S3 Cost calculation. 

This is needed as part of the evergreen change -- [PR](https://github.com/evergreen-ci/evergreen/pull/10231)
