### PR TITLE
DEVPROD-34603 - Return correct uploaded bytes for Stream uploads

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -111,6 +111,12 @@ type StreamPutCounter interface {
 	PutWithCount(ctx context.Context, key string, r io.Reader) (int, error)
 }
 
+// StreamPutCounterWithBytes extends StreamPutCounter to also return bytes written to S3.
+type StreamPutCounterWithBytes interface {
+	Bucket
+	PutWithCountAndBytes(ctx context.Context, key string, r io.Reader) (puts int, bytesWritten int64, err error)
+}
+
 // FastGetS3Bucket is a Bucket but with an additional method, GetToWriter. Only S3
 // bucket types can support this access pattern.
 type FastGetS3Bucket interface {

--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -900,11 +900,11 @@ func isAWSServiceError(err error) bool {
 	return errors.As(err, &apiErr) && apiErr.ErrorFault() == smithy.FaultServer
 }
 
-// putHelper uploads r to key and returns the number of S3 PUT-equivalent API calls made.
-// The count is returned even on error because calls that reached AWS are billed.
-func putHelper(ctx context.Context, b *s3Bucket, key string, r io.Reader) (int, error) {
+// putHelper uploads r to key and returns PUT count and bytes written to S3 (post-compression
+// for compressed buckets). Both are returned even on error since AWS bills completed calls.
+func putHelper(ctx context.Context, b *s3Bucket, key string, r io.Reader) (puts int, bytesWritten int64, err error) {
 	if b.dryRun {
-		return 0, nil
+		return 0, 0, nil
 	}
 
 	if b.compress {
@@ -913,14 +913,23 @@ func putHelper(ctx context.Context, b *s3Bucket, key string, r io.Reader) (int, 
 		w := gzip.NewWriter(&buf)
 
 		if _, err := io.Copy(w, r); err != nil {
-			return 0, errors.Wrap(err, "gzipping file")
+			return 0, 0, errors.Wrap(err, "gzipping file")
 		}
 
 		if err := w.Close(); err != nil {
-			return 0, errors.Wrap(err, "closing gzip writer")
+			return 0, 0, errors.Wrap(err, "closing gzip writer")
 		}
 
 		r = bytes.NewReader(buf.Bytes())
+		bytesWritten = int64(buf.Len())
+	} else if rs, ok := r.(io.ReadSeeker); ok {
+		// Measure remaining bytes so the count reflects what S3 actually receives.
+		if start, seekErr := rs.Seek(0, io.SeekCurrent); seekErr == nil {
+			if end, seekErr := rs.Seek(0, io.SeekEnd); seekErr == nil {
+				bytesWritten = end - start
+				_, _ = rs.Seek(start, io.SeekStart)
+			}
+		}
 	}
 
 	var putCount atomic.Int32
@@ -957,8 +966,8 @@ func putHelper(ctx context.Context, b *s3Bucket, key string, r io.Reader) (int, 
 		input.ContentEncoding = aws.String(compressionEncoding)
 	}
 
-	_, err := uploader.Upload(ctx, input)
-	return int(putCount.Load()), errors.Wrapf(err, "uploading file")
+	_, uploadErr := uploader.Upload(ctx, input)
+	return int(putCount.Load()), bytesWritten, errors.Wrapf(uploadErr, "uploading file")
 }
 
 func (s *s3BucketSmall) Put(ctx context.Context, key string, r io.Reader) error {
@@ -971,7 +980,7 @@ func (s *s3BucketSmall) Put(ctx context.Context, key string, r io.Reader) error 
 		"key":           key,
 	})
 
-	_, err := putHelper(ctx, &s.s3Bucket, key, r)
+	_, _, err := putHelper(ctx, &s.s3Bucket, key, r)
 	return err
 }
 
@@ -985,7 +994,7 @@ func (s *s3BucketLarge) Put(ctx context.Context, key string, r io.Reader) error 
 		"key":           key,
 	})
 
-	_, err := putHelper(ctx, &s.s3Bucket, key, r)
+	_, _, err := putHelper(ctx, &s.s3Bucket, key, r)
 	return err
 }
 
@@ -1098,11 +1107,19 @@ func (s *s3Bucket) UploadWithCount(ctx context.Context, key, path string) (int, 
 	}
 	defer f.Close()
 
-	return putHelper(ctx, s, key, f)
+	puts, _, err := putHelper(ctx, s, key, f)
+	return puts, err
 }
 
 // PutWithCount streams r to key; returns the PUT count even on error since calls that reached AWS are billed.
 func (s *s3Bucket) PutWithCount(ctx context.Context, key string, r io.Reader) (int, error) {
+	puts, _, err := putHelper(ctx, s, key, r)
+	return puts, err
+}
+
+// PutWithCountAndBytes streams r to key; returns PUT count and bytes written to S3
+// (post-compression for compressed buckets). Both are returned even on error.
+func (s *s3Bucket) PutWithCountAndBytes(ctx context.Context, key string, r io.Reader) (int, int64, error) {
 	grip.DebugWhen(ctx, s.verbose, message.Fields{
 		"type":          "s3",
 		"dry_run":       s.dryRun,

--- a/s3_bucket_util_test.go
+++ b/s3_bucket_util_test.go
@@ -1192,12 +1192,13 @@ func makeMoveObjectsWithXMLIncompatibleCharsTest(ctx context.Context, s3Credenti
 	}
 }
 
-func TestPutHelperDryRunReturnsZeroPuts(t *testing.T) {
+func TestPutHelperDryRunReturnsZeroPutsAndBytes(t *testing.T) {
 	ctx := t.Context()
 	b := &s3Bucket{dryRun: true}
-	n, err := putHelper(ctx, b, "key", bytes.NewReader([]byte("data")))
+	puts, bytesWritten, err := putHelper(ctx, b, "key", bytes.NewReader([]byte("data")))
 	assert.NoError(t, err)
-	assert.Equal(t, 0, n)
+	assert.Equal(t, 0, puts)
+	assert.Equal(t, int64(0), bytesWritten)
 }
 
 func TestS3BucketImplementsPutCounter(t *testing.T) {
@@ -1244,4 +1245,24 @@ func TestS3BucketImplementsStreamPutCounter(t *testing.T) {
 	n, err = large.PutWithCount(ctx, "key", bytes.NewReader([]byte("hello")))
 	assert.NoError(t, err)
 	assert.Equal(t, 0, n)
+}
+
+func TestS3BucketImplementsStreamPutCounterWithBytes(t *testing.T) {
+	ctx := t.Context()
+
+	small := &s3BucketSmall{s3Bucket: s3Bucket{dryRun: true}}
+	large := &s3BucketLarge{s3Bucket: s3Bucket{dryRun: true}}
+
+	var _ StreamPutCounterWithBytes = small
+	var _ StreamPutCounterWithBytes = large
+
+	puts, bytesWritten, err := small.PutWithCountAndBytes(ctx, "key", bytes.NewReader([]byte("hello")))
+	assert.NoError(t, err)
+	assert.Equal(t, 0, puts)
+	assert.Equal(t, int64(0), bytesWritten)
+
+	puts, bytesWritten, err = large.PutWithCountAndBytes(ctx, "key", bytes.NewReader([]byte("hello")))
+	assert.NoError(t, err)
+	assert.Equal(t, 0, puts)
+	assert.Equal(t, int64(0), bytesWritten)
 }


### PR DESCRIPTION
DEVPROD-34603

Description:
Fixes a bug where the S3 log upload helper always returned raw byte count instead of actual uploaded bytes. For compressed buckets, it now returns the post-compression size. For uncompressed buckets, it uses a seek-based measurement.

Testing:
Added test cases for coverage

[Evergreen-App PR](https://github.com/evergreen-ci/evergreen/pull/10333) that makes use of this change