### PR TITLE
DEVPROD-29864: Add pause in MoveObjects to avoid S3 rate limiting

### DIFF
--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -1579,6 +1579,12 @@ func (s *s3Bucket) MoveObjects(ctx context.Context, destBucket Bucket, sourceKey
 				catcher.Add(s.deleteObjectsWrapper(ctx, toDelete))
 				count = 0
 				toDelete = &s3Types.Delete{}
+				// Pause between batches to avoid S3 rate-limit errors (503 SlowDown).
+				select {
+				case <-ctx.Done():
+					return catcher.Resolve()
+				case <-time.After(500 * time.Millisecond):
+				}
 			}
 			toDelete.Objects = append(toDelete.Objects, obj)
 			count++


### PR DESCRIPTION
 DEVPROD-29864
 
 ### Description

When MoveObjects deletes objects in batches, it was issuing DeleteObjects calls back-to-back with no delay. This would sometimes cause us to get rate limited.

This adds a 500ms pause between batch delete calls to try to avoid it. 