### PR TITLE
DEVPROD-17572: Adding No Such Key Error handling for S3.Get when no file exists

### DIFF
--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -1059,6 +1059,10 @@ func (s *s3Bucket) GetToWriter(ctx context.Context, key string, w io.WriterAt) e
 	})
 
 	if _, err := downloader.Download(ctx, w, input); err != nil {
+		var apiErr smithy.APIError
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "NoSuchKey" {
+			return MakeKeyNotFoundError(err)
+		}
 		return errors.Wrapf(err, "downloading file")
 	}
 

--- a/s3_bucket_util_test.go
+++ b/s3_bucket_util_test.go
@@ -951,6 +951,22 @@ func getS3LargeBucketTests(ctx context.Context, tempdir string, s3Credentials aw
 			},
 		},
 		{
+			id: "TestGetToWriterMissingKeyIsKeyNotFoundError",
+			test: func(t *testing.T, b Bucket) {
+				s3b, ok := b.(FastGetS3Bucket)
+				require.True(t, ok)
+
+				ctx := t.Context()
+				f, err := os.CreateTemp(t.TempDir(), "get-to-writer-missing")
+				require.NoError(t, err)
+				t.Cleanup(func() { assert.NoError(t, f.Close()) })
+
+				err = s3b.GetToWriter(ctx, testutil.NewUUID(), f)
+				require.Error(t, err)
+				assert.True(t, IsKeyNotFoundError(err))
+			},
+		},
+		{
 			id: "TestCompressingWriter",
 			test: func(t *testing.T, b Bucket) {
 				rawBucket := b.(*s3BucketLarge)


### PR DESCRIPTION
DEVPROD-17572

### Description
When downloading a file that doesn't exist on S3, the fast-download path was returning a generic error instead of a key-not found error. Adding a clear return error so callers can handle this correctly

### Testing
Added unit test cases

[Evergreen-App PR](https://github.com/evergreen-ci/evergreen/pull/10342) that makes use of this change