### PR TITLE
DEVPROD-29864: Apply delete pause before final batch in MoveObjects

### DIFF
--- a/s3_bucket.go
+++ b/s3_bucket.go
@@ -1597,18 +1597,26 @@ func (s *s3Bucket) MoveObjects(ctx context.Context, destBucket Bucket, sourceKey
 		toDelete := &s3Types.Delete{}
 		for _, obj := range objectsToDelete {
 			if count == s.batchSize {
-				catcher.Add(s.deleteObjectsWrapper(ctx, toDelete))
-				count = 0
-				toDelete = &s3Types.Delete{}
-				// Pause between batches to avoid S3 rate-limit errors (503 SlowDown).
+				// Pause before each batch to avoid S3 rate-limit errors (503 SlowDown).
 				select {
 				case <-ctx.Done():
 					return catcher.Resolve()
 				case <-time.After(500 * time.Millisecond):
 				}
+				catcher.Add(s.deleteObjectsWrapper(ctx, toDelete))
+				count = 0
+				toDelete = &s3Types.Delete{}
 			}
 			toDelete.Objects = append(toDelete.Objects, obj)
 			count++
+		}
+		// Pause before the final batch to avoid S3 rate-limit errors (503 SlowDown).
+		// This ensures the pause applies even when all objects fit in a single batch,
+		// which is the typical case for most move operations.
+		select {
+		case <-ctx.Done():
+			return catcher.Resolve()
+		case <-time.After(500 * time.Millisecond):
 		}
 		catcher.Add(s.deleteObjectsWrapper(ctx, toDelete))
 	}


### PR DESCRIPTION
DEVPROD-29864

### Summary

The prior fix (#151) only slept between batches, which only fires when a move exceeds 1000 objects. Most task log moves are far smaller, so the pause never applied. This moves the sleep to fire before every deleteObjectsWrapper call, including the single final batch that covers the typical case.

### Testing 
Existing tests and will continue to monitor splunk 